### PR TITLE
Clarify the paragraph concerning HTML escalation:

### DIFF
--- a/html-plan.html
+++ b/html-plan.html
@@ -93,9 +93,12 @@
           agreement on IPR-friendly stable snapshots.
         </p>
         <p>
-          The question of escalation is more subtle. Most WHATWG specifications effectively operate
-          under consensus and escalation policies that are in effect no worse than those afforded by
-          the best W3C working groups. WHATWG HTML does however suffer from
+          The question of escalation is more subtle. 
+          While the overwhelming majority of bugs processed in the development of
+          the WHATWG HTML Living Standard are resolved in ways that meet the W3C
+          definition of 
+          <a href="http://www.w3.org/2014/Process-20140801/#Consensus">consensus</a>,
+          WHATWG HTML does however suffer from
           “<a href="http://berjon.com/is-html-too-big-to-fail/">too big to fail</a>” externalities
           that decrease the editor’s responsibility for his actions and thereby negatively affect
           the specification’s evolution.


### PR DESCRIPTION
1) Make it clear that the point about meeting the W3C definition of
consensus applies not just to "other" specifications produced by the
WHATWG, but to the overwhelming majority of changes made to the WHATWG
HTML LS itself.

2) Avoid the distraction of bringing in other specifications.
